### PR TITLE
azuread_application attribute application_id has been deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+Changed
+  * [GH-1](https://github.com/claranet/terraform-azurerm-service-principal/pull/1): `azuread_application` attribute `application_id` has been deprecated.
+
 # v7.2.1 - 2023-08-18
 
 Fixed

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ module "sp" {
 
 | Name | Version |
 |------|---------|
-| azuread | ~> 2.0 |
+| azuread | ~> 2.44 |
 | azurerm | ~> 3.0 |
 | random | ~> 3.5 |
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,7 @@ output "sp_name" {
 
 output "sp_app_id" {
   description = "Azure Service Principal App ID."
-  value       = azuread_application.aad_app.application_id
+  value       = azuread_application.aad_app.client_id
 }
 
 output "sp_object_id" {

--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.0"
+      version = "~> 2.44"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes proposed in this pull request

Follow-up to the following update in version 2.45.0 of hashicorp/terraform-provider-azuread,
as per https://github.com/hashicorp/terraform-provider-azuread/pull/1214

> `azuread_application` - export the client_id attribute,
> deprecate the `application_id` attribute

The `terraform validate` also issues the following warning for version 7.2.1 of this module:

```
│ Warning: Deprecated attribute
│
│   on .terraform/modules/sp/outputs.tf line 8, in output "sp_app_id":
│    8:   value       = azuread_application.aad_app.application_id
│
│ The attribute "application_id" is deprecated. Refer to the provider documentation for details.
```

@claranet/fr-azure-reviewers
